### PR TITLE
SwiftUI 폰트 extension 구현

### DIFF
--- a/BoostDesignSystem/Package.swift
+++ b/BoostDesignSystem/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "BoostDesignSystem",
+  platforms: [.macOS(.v10_15), .iOS(.v13)],
   products: [
     // Products define the executables and libraries a package produces, making them visible to other packages.
     .library(

--- a/BoostDesignSystem/Package.swift
+++ b/BoostDesignSystem/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
     // Targets are the basic building blocks of a package, defining a module or a test suite.
     // Targets can depend on other targets in this package and products from dependencies.
     .target(
-      name: "BoostDesignSystem"),
+      name: "BoostDesignSystem",
+      resources: [.process("Resources")]
+    ),
     .testTarget(
       name: "BoostDesignSystemTests",
       dependencies: ["BoostDesignSystem"]),

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/BoostDesignSystem.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/BoostDesignSystem.swift
@@ -1,2 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/View+Font.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/View+Font.swift
@@ -64,6 +64,8 @@ private extension BoostFont {
         .custom(Pretendard.medium.rawValue, size: size)
     case let .caption1(.regular(size)):
         .custom(Pretendard.regular.rawValue, size: size)
+    case let .pretendard(style, size):
+        .custom(style.rawValue, size: size)
     }
   }
 }

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/View+Font.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/View+Font.swift
@@ -1,0 +1,14 @@
+//
+//  View+Font.swift
+//
+//
+//  Created by Hyun on 9/3/24.
+//
+
+import SwiftUI
+
+public extension View {
+  func font(_ style: BoostFont) -> some View {
+    self
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/View+Font.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/View+Font.swift
@@ -9,6 +9,61 @@ import SwiftUI
 
 public extension View {
   func font(_ style: BoostFont) -> some View {
-    self
+    self.font(style.font)
+  }
+}
+
+private extension BoostFont {
+  var font: Font {
+    switch self {
+    case .heading1(.bold):
+        .custom(Pretendard.bold.rawValue, size: 32)
+    case .heading1(.medium):
+        .custom(Pretendard.medium.rawValue, size: 32)
+    case .heading1(.regular):
+        .custom(Pretendard.regular.rawValue, size: 32)
+    case .heading2(.bold):
+        .custom(Pretendard.bold.rawValue, size: 28)
+    case .heading2(.medium):
+        .custom(Pretendard.medium.rawValue, size: 28)
+    case .heading2(.regular):
+        .custom(Pretendard.regular.rawValue, size: 28)
+    case .heading3(.bold):
+        .custom(Pretendard.bold.rawValue, size: 24)
+    case .heading3(.medium):
+        .custom(Pretendard.medium.rawValue, size: 24)
+    case .heading3(.regular):
+        .custom(Pretendard.regular.rawValue, size: 24)
+    case .subheading1(.bold):
+        .custom(Pretendard.bold.rawValue, size: 20)
+    case .subheading1(.medium):
+        .custom(Pretendard.medium.rawValue, size: 20)
+    case .subheading1(.regular):
+        .custom(Pretendard.regular.rawValue, size: 20)
+    case .subheading2(.bold):
+        .custom(Pretendard.bold.rawValue, size: 18)
+    case .subheading2(.medium):
+        .custom(Pretendard.medium.rawValue, size: 18)
+    case .subheading2(.regular):
+        .custom(Pretendard.regular.rawValue, size: 18)
+    case .body1(.bold):
+        .custom(Pretendard.bold.rawValue, size: 16)
+    case .body1(.medium):
+        .custom(Pretendard.medium.rawValue, size: 16)
+    case .body1(.regular):
+        .custom(Pretendard.regular.rawValue, size: 16)
+    case .body2(.bold):
+        .custom(Pretendard.bold.rawValue, size: 14)
+    case .body2(.medium):
+        .custom(Pretendard.medium.rawValue, size: 14)
+    case .body2(.regular):
+        .custom(Pretendard.regular.rawValue, size: 14)
+    case let .caption1(.bold(size)):
+        .custom(Pretendard.bold.rawValue, size: size)
+    case let .caption1(.medium(size)):
+        .custom(Pretendard.medium.rawValue, size: size)
+    case let .caption1(.regular(size)):
+        .custom(Pretendard.regular.rawValue, size: size)
+    }
   }
 }

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
@@ -16,6 +16,7 @@ public enum BoostFont {
   case body1(Weight)
   case body2(Weight)
   case caption1(WeightWithSize)
+  case pretendard(_ name: Pretendard, size: CGFloat)
 
   public enum Weight {
     case bold

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
@@ -30,3 +30,17 @@ public enum BoostFont {
     case regular(CGFloat)
   }
 }
+
+
+struct ContentView: View {
+  var body: some View {
+    Text("Hello, World!")
+      .font(.pretendard(.black, size: 20))
+  }
+}
+
+#Preview {
+  FontRegistrar.registerFonts()
+  return ContentView()
+
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
@@ -1,0 +1,31 @@
+//
+//  BoostFont.swift
+//
+//
+//  Created by Hyun on 9/3/24.
+//
+
+import SwiftUI
+
+public enum BoostFont {
+  case heading1(Weight)
+  case heading2(Weight)
+  case heading3(Weight)
+  case subheading1(Weight)
+  case subheading2(Weight)
+  case body1(Weight)
+  case body2(Weight)
+  case caption1(WeightWithSize)
+
+  public enum Weight {
+    case bold
+    case medium
+    case regular
+  }
+
+  public enum WeightWithSize {
+    case bold(Int)
+    case medium(Int)
+    case regular(Int)
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
@@ -24,8 +24,8 @@ public enum BoostFont {
   }
 
   public enum WeightWithSize {
-    case bold(Int)
-    case medium(Int)
-    case regular(Int)
+    case bold(CGFloat)
+    case medium(CGFloat)
+    case regular(CGFloat)
   }
 }

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/FontRegistrar.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/FontRegistrar.swift
@@ -1,0 +1,39 @@
+//
+//  FontRegistrar.swift
+//
+//
+//  Created by Hyun on 9/3/24.
+//
+
+import CoreText
+import Foundation
+
+// MARK: - FontRegistrar
+
+/// `FontRegistrar` 열거형은 커스텀 폰트를 등록하는 데 사용됩니다.
+public enum FontRegistrar {
+  /// 이 메서드는 편행 폰트인 `Pretendard`를 등록합니다.
+  /// 각각의 폰트 이름을 순회하면서 `registerFont` 메서드를 호출하여 폰트를 등록합니다.
+  public static func registerFonts() {
+    // Pretendard 폰트 등록
+    for fontName in Pretendard.allCases.map(\.rawValue) {
+      registerFont(bundle: .module, fontName: fontName, fontExtension: "otf")
+    }
+  }
+
+  /// 주어진 폰트 이름과 확장자를 사용하여 폰트를 동적으로 등록합니다.
+  /// - Parameters:
+  ///   - bundle: 폰트 파일을 포함하고 있는 번들.
+  ///   - fontName: 등록할 폰트의 이름.
+  ///   - fontExtension: 폰트 파일의 확장자.
+  private static func registerFont(bundle: Bundle, fontName: String, fontExtension: String) {
+    guard let fontURL = bundle.url(forResource: fontName, withExtension: fontExtension),
+          let fontDataDriver = CGDataProvider(url: fontURL as CFURL),
+          let font = CGFont(fontDataDriver)
+    else {
+      return // 폰트 로딩에 실패할 경우 함수를 종료합니다.
+    }
+    // CoreText를 사용하여 폰트를 시스템에 등록합니다.
+    CTFontManagerRegisterGraphicsFont(font, nil)
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/FontRegistrar.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/FontRegistrar.swift
@@ -12,10 +12,7 @@ import Foundation
 
 /// `FontRegistrar` 열거형은 커스텀 폰트를 등록하는 데 사용됩니다.
 public enum FontRegistrar {
-  /// 이 메서드는 편행 폰트인 `Pretendard`를 등록합니다.
-  /// 각각의 폰트 이름을 순회하면서 `registerFont` 메서드를 호출하여 폰트를 등록합니다.
   public static func registerFonts() {
-    // Pretendard 폰트 등록
     for fontName in Pretendard.allCases.map(\.rawValue) {
       registerFont(bundle: .module, fontName: fontName, fontExtension: "otf")
     }
@@ -33,7 +30,7 @@ public enum FontRegistrar {
     else {
       return // 폰트 로딩에 실패할 경우 함수를 종료합니다.
     }
-    // CoreText를 사용하여 폰트를 시스템에 등록합니다.
+
     CTFontManagerRegisterGraphicsFont(font, nil)
   }
 }

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/Pretendard.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/Pretendard.swift
@@ -9,17 +9,12 @@
 
 public enum Pretendard: String, CaseIterable {
   case black = "Pretendard-Black"
-
   case extraBold = "Pretendard-ExtraBold"
   case bold = "Pretendard-Bold"
   case semiBold = "Pretendard-SemiBold"
-
   case medium = "Pretendard-Medium"
-
   case regular = "Pretendard-Regular"
-
   case light = "Pretendard-Light"
   case extraLight = "Pretendard-ExtraLight"
-
   case thin = "Pretendard-Thin"
 }

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/Pretendard.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/Pretendard.swift
@@ -7,7 +7,7 @@
 
 // MARK: - Pretendard
 
-enum Pretendard: String, CaseIterable {
+public enum Pretendard: String, CaseIterable {
   case black = "Pretendard-Black"
 
   case extraBold = "Pretendard-ExtraBold"

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/Pretendard.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/Pretendard.swift
@@ -1,0 +1,25 @@
+//
+//  Pretendard.swift
+//  BoostDesignSystem
+//
+//  Created by Hyun on 9/3/24.
+//
+
+// MARK: - Pretendard
+
+enum Pretendard: String, CaseIterable {
+  case black = "Pretendard-Black"
+
+  case extraBold = "Pretendard-ExtraBold"
+  case bold = "Pretendard-Bold"
+  case semiBold = "Pretendard-SemiBold"
+
+  case medium = "Pretendard-Medium"
+
+  case regular = "Pretendard-Regular"
+
+  case light = "Pretendard-Light"
+  case extraLight = "Pretendard-ExtraLight"
+
+  case thin = "Pretendard-Thin"
+}


### PR DESCRIPTION
Figma Library에 맞게 폰트를 구현했습니다.

### 사용법

SwiftUI에 제공되는 font 메서드와 동일하게 가져갔습니다.
(새로운 modifier보다 익숙하고 명확한 font 메서드가 낫다고 판단했습니다)

```swift
struct ContentView: View {
  var body: some View {
    VStack {
      Text("This is subheading1 font")
        .font(.subheading1(.bold)) // SubHeading1 크기에 굵기는 bold인 폰트
      Text("This is body Font")
        .font(.body1(.medium)) // body1 크기에 굵기는 medium인 폰트
      Text("This is caption1 Font")
        .font(.caption1(.regular(10))) // caption1, 굵기는 regular, 크기는 10인 폰트
      Text("This is Custom pretendard Font")
        .font(.pretendard(.black, size: 20)) // Pretendard-Black 굵기에 크기는 20인 폰트
    }
  }
}
```

구현된 폰트는 다음과 같습니다.

```swift
public enum BoostFont {

  case heading1(Weight)
  case heading2(Weight)
  case heading3(Weight)

  case subheading1(Weight)
  case subheading2(Weight)

  case body1(Weight)
  case body2(Weight)

  case caption1(WeightWithSize)

  // custom용
  case pretendard(_ name: Pretendard, size: CGFloat)

  public enum Weight {
    case bold
    case medium
    case regular
  }

  public enum WeightWithSize {
    case bold(CGFloat)
    case medium(CGFloat)
    case regular(CGFloat)
  }
}
```

## 고민했던 점

1. figma 라이브러리의`caption1`의 경우, 두 가의 Font Size(12, 10)를 갖고 있어서 `.font(.caption1(.bold(12)))`과 같이 굵기 다음에 사이즈를 제시해주어야 합니다.
   - 두 값을 개발자가 직접 제공하는 것보다 enum으로 두 케이스를 만들어 할당해줄까도 고려해봤지만, 단순 숫자표기의 네이밍을 여러분과 함께 고민해봐야할 것 같아 보류했습니다.
      - e.g. `_10`, `_12` 또는 `size10`, `size12`, ... 등
2. 혹여나 Font library로 등록되지 않는 폰트를 쓰는 경우가 보일 때, custom하게 Pretendard 폰트를 적용할 수 있도록 `pretendard(_:size:)`를 넣었습니다.
   - 원래는 이름을 `custom`으로 시스템에서 제공하는 Font메서드처럼 해결하려 했는데, 자동완성에서 불편함을 보여 `.custom` -> `.pretendard`로 수정했습니다.


## ⚠️ 사용시 주의해야할 점

해당 SPM을 추가하시고나서 `FontRegistrar.registerFonts()`를 실행해주셔야 합니다. 마치 Firebase의 configure()메서드 처럼요.
그 이유는, 앱에서 info.plist에 폰트를 적용했던 것처럼, SPM에서도 이와 비슷한 작업을 해주어야하는데요. 그 코드가 `FontRegistrar` 내부 메서드로 감싸져 있습니다. :)