### PR TITLE
GrayScale 색상 및 Color initializer extension 추가

### DIFF
--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray100.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray100.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xF4",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xF4",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray200.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray200.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xE7",
+          "red" : "0xE5"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xE7",
+          "red" : "0xE5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray300.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray300.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDB",
+          "green" : "0xD5",
+          "red" : "0xD1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDB",
+          "green" : "0xD5",
+          "red" : "0xD1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray400.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray400.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAF",
+          "green" : "0xA3",
+          "red" : "0x9C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAF",
+          "green" : "0xA3",
+          "red" : "0x9C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray50.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray50.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xFA",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xFA",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray500.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray500.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0x72",
+          "red" : "0x6B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0x72",
+          "red" : "0x6B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray600.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray600.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x63",
+          "green" : "0x55",
+          "red" : "0x4B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x63",
+          "green" : "0x55",
+          "red" : "0x4B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray700.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray700.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x51",
+          "green" : "0x41",
+          "red" : "0x37"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x51",
+          "green" : "0x41",
+          "red" : "0x37"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray800.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray800.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x37",
+          "green" : "0x29",
+          "red" : "0x1F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x37",
+          "green" : "0x29",
+          "red" : "0x1F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray900.colorset/Contents.json
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Resources/Colors.xcassets/Gray Scale/gray900.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x07",
+          "red" : "0x03"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x07",
+          "red" : "0x03"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/Color+init.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/Color+init.swift
@@ -1,0 +1,50 @@
+//
+//  Color+init.swift
+//
+//
+//  Created by Hyun on 9/5/24.
+//
+
+import SwiftUI
+
+public extension Color {
+
+  /// 16진수 문자열로부터 Color를 초기화합니다.
+  /// - Parameters:
+  ///   - hex: RGB 형식의 16진수 문자열 (예: "FF0000", "#FF0000")
+  ///   - alpha: 불투명도 값 (0.0 ~ 1.0, 기본값 `1.0`)
+  init(_ hex: String, alpha: Double = 1) {
+    let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+    var int: UInt64 = 0
+    Scanner(string: hex).scanHexInt64(&int)
+    let r, g, b: UInt64
+    switch hex.count {
+    case 6: // RGB - pattern인 경우
+      (r, g, b) = (int >> 16, int >> 8 & 0xFF, int & 0xFF)
+    default:
+      (r, g, b) = (0, 0, 0) // clear color
+    }
+
+    self.init(
+      .sRGB,
+      red: Double(r) / 255,
+      green: Double(g) / 255,
+      blue:  Double(b) / 255,
+      opacity: alpha
+    )
+  }
+
+  /// UInt 타입의 RGB 값으로부터 Color를 초기화합니다.
+  /// - Parameters:
+  ///   - hex: RGB 형식의 UInt 값 (예: 0xFF0000)
+  ///   - alpha: 불투명도 값 (0.0 ~ 1.0, 기본값 `1.0`)
+  init(_ hex: UInt, alpha: Double = 1) {
+    self.init(
+      .sRGB,
+      red: Double(hex >> 16) / 255,
+      green: Double((hex >> 08) & 0xff) / 255,
+      blue: Double(hex & 0xff) / 255,
+      opacity: alpha
+    )
+  }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/ShapeStyle+Color.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Extensions/ShapeStyle+Color.swift
@@ -1,0 +1,21 @@
+//
+//  ShapeStyle+Color.swift
+//
+//
+//  Created by Hyun on 9/5/24.
+//
+
+import SwiftUI
+
+public extension ShapeStyle where Self == Color {
+  static var gray50: Color { .init("gray50", bundle: .module) }
+  static var gray100: Color { .init("gray100", bundle: .module) }
+  static var gray200: Color { .init("gray200", bundle: .module) }
+  static var gray300: Color { .init("gray300", bundle: .module) }
+  static var gray400: Color { .init("gray400", bundle: .module) }
+  static var gray500: Color { .init("gray500", bundle: .module) }
+  static var gray600: Color { .init("gray600", bundle: .module) }
+  static var gray700: Color { .init("gray700", bundle: .module) }
+  static var gray800: Color { .init("gray800", bundle: .module) }
+  static var gray900: Color { .init("gray900", bundle: .module) }
+}

--- a/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
+++ b/BoostDesignSystem/Sources/BoostDesignSystem/Sources/Fonts/BoostFont.swift
@@ -30,17 +30,3 @@ public enum BoostFont {
     case regular(CGFloat)
   }
 }
-
-
-struct ContentView: View {
-  var body: some View {
-    Text("Hello, World!")
-      .font(.pretendard(.black, size: 20))
-  }
-}
-
-#Preview {
-  FontRegistrar.registerFonts()
-  return ContentView()
-
-}


### PR DESCRIPTION
## 1. Gray Scale 추가

라이브러리에 네이버지도에 맞는 색상이 없어 GrayScale만 따로 추가해두었습니다.
나머지 색상은 각자 입맛에 맞게 extension으로 파야할 것 같습니다.

## 2. Color extension 추가

무엇을 좋아할지 몰라 두 initializer를 만들어두었습니다.

### 2-1. Int를 활용한 Color initializer

```swift
Color(0xFF0000, alpha: 0.5) // 약간 불투명한 빨간색
Color(0x00FF00) // 녹색, alpha값은 1이 기본값
```

### 2-2. String을 활용한 Color initializer

```swift
Color("#FF0000", alpha: 0.5) // 약간 불투명한 빨간색
Color("00FF00") // 녹색, alpha값은 1이 기본값, `#`을 제거해도됨
```
